### PR TITLE
Add an Admin page that allows deletion of comments

### DIFF
--- a/leoism/step/portfolio/pom.xml
+++ b/leoism/step/portfolio/pom.xml
@@ -24,6 +24,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>jstl</artifactId>
+      <version>1.2</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>

--- a/leoism/step/portfolio/src/main/java/com/google/sps/data/CommentInformation.java
+++ b/leoism/step/portfolio/src/main/java/com/google/sps/data/CommentInformation.java
@@ -21,15 +21,13 @@ public final class CommentInformation {
   private final String comment;
   private final long timestamp;
   private final double sentimentScore;
-  private final String key;
 
   public CommentInformation(String comment, String name, long timestamp,
-                            double sentimentScore, String key) {
+                            double sentimentScore) {
     this.comment = comment;
     this.name = name;
     this.timestamp = timestamp;
     this.sentimentScore = sentimentScore;
-    this.key = key;
   }
 
   public String getName() { return name; }
@@ -40,5 +38,4 @@ public final class CommentInformation {
 
   public double getSentimentScore() { return sentimentScore; }
 
-  public String getKey() { return key; }
 }

--- a/leoism/step/portfolio/src/main/java/com/google/sps/data/CommentInformation.java
+++ b/leoism/step/portfolio/src/main/java/com/google/sps/data/CommentInformation.java
@@ -34,7 +34,7 @@ public final class CommentInformation {
 
   public String getComment() { return comment; }
 
-  public long getTimeStamp() { return timestamp; }
+  public long getTimestamp() { return timestamp; }
 
   public double getSentimentScore() { return sentimentScore; }
 }

--- a/leoism/step/portfolio/src/main/java/com/google/sps/data/CommentInformation.java
+++ b/leoism/step/portfolio/src/main/java/com/google/sps/data/CommentInformation.java
@@ -22,20 +22,26 @@ public final class CommentInformation {
   private final long timestamp;
   private final double sentimentScore;
 
-  public CommentInformation(String comment, String name, long timestamp,
-                            double sentimentScore) {
+  public CommentInformation(String comment, String name, long timestamp, double sentimentScore) {
     this.comment = comment;
     this.name = name;
     this.timestamp = timestamp;
     this.sentimentScore = sentimentScore;
   }
 
-  public String getName() { return name; }
+  public String getName() {
+    return name;
+  }
 
-  public String getComment() { return comment; }
+  public String getComment() {
+    return comment;
+  }
 
-  public long getTimestamp() { return timestamp; }
+  public long getTimestamp() {
+    return timestamp;
+  }
 
-  public double getSentimentScore() { return sentimentScore; }
-
+  public double getSentimentScore() {
+    return sentimentScore;
+  }
 }

--- a/leoism/step/portfolio/src/main/java/com/google/sps/data/CommentInformation.java
+++ b/leoism/step/portfolio/src/main/java/com/google/sps/data/CommentInformation.java
@@ -14,7 +14,11 @@
 
 package com.google.sps.data;
 
-/** Class containing Comment information. */
+/**
+ * Class containing information on Comments. The class allows converting the properties of a comment
+ * into a JSON parsable object that the JavaScript can read to display the comments on a page. The
+ * timestamp is stored in milliseconds since the Unix Epoch.
+ */
 public final class CommentInformation {
 
   private final String name;
@@ -37,6 +41,7 @@ public final class CommentInformation {
     return comment;
   }
 
+  // Returns the milliseconds since the Unix Epoch.
   public long getTimestamp() {
     return timestamp;
   }

--- a/leoism/step/portfolio/src/main/java/com/google/sps/data/CommentInformation.java
+++ b/leoism/step/portfolio/src/main/java/com/google/sps/data/CommentInformation.java
@@ -21,13 +21,15 @@ public final class CommentInformation {
   private final String comment;
   private final long timestamp;
   private final double sentimentScore;
+  private final String key;
 
   public CommentInformation(String comment, String name, long timestamp,
-                            double sentimentScore) {
+                            double sentimentScore, String key) {
     this.comment = comment;
     this.name = name;
     this.timestamp = timestamp;
     this.sentimentScore = sentimentScore;
+    this.key = key;
   }
 
   public String getName() { return name; }
@@ -37,4 +39,6 @@ public final class CommentInformation {
   public long getTimestamp() { return timestamp; }
 
   public double getSentimentScore() { return sentimentScore; }
+
+  public String getKey() { return key; }
 }

--- a/leoism/step/portfolio/src/main/java/com/google/sps/servlets/AdminServlet.java
+++ b/leoism/step/portfolio/src/main/java/com/google/sps/servlets/AdminServlet.java
@@ -34,8 +34,7 @@ import java.util.ArrayList;
 import java.util.Map;
 
 /**
- * Servlet that returns some example content. TODO: modify this file to handle
- * comments data
+ * Servlet that deletes comments from the Datastore upon user request.
  */
 @WebServlet("/admin")
 public class AdminServlet extends HttpServlet {

--- a/leoism/step/portfolio/src/main/java/com/google/sps/servlets/AdminServlet.java
+++ b/leoism/step/portfolio/src/main/java/com/google/sps/servlets/AdminServlet.java
@@ -16,7 +16,6 @@ package com.google.sps.servlets;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
-import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.PreparedQuery;
@@ -25,19 +24,14 @@ import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
 import com.google.gson.Gson;
-import com.google.sps.data.CommentInformation;
 import java.io.IOException;
+import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.ServletException;
-import java.util.ArrayList;
-import java.util.Map;
 
-/**
- * Servlet that deletes comments from the Datastore upon user request.
- */
+/** Servlet that deletes comments from the Datastore upon user request. */
 @WebServlet("/admin")
 public class AdminServlet extends HttpServlet {
   @Override
@@ -51,20 +45,17 @@ public class AdminServlet extends HttpServlet {
       return;
     }
 
-    Query query =
-        new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
+    Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
 
     request.setAttribute("commentData", results.asIterator());
-    request.getRequestDispatcher("/pages/AdminPage.jsp")
-        .forward(request, response);
+    request.getRequestDispatcher("/pages/AdminPage.jsp").forward(request, response);
   }
 
   @Override
-  public void doPost(HttpServletRequest request, HttpServletResponse response)
-      throws IOException {
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     UserService userService = UserServiceFactory.getUserService();
 
     if (!userService.isUserLoggedIn()) {
@@ -76,8 +67,7 @@ public class AdminServlet extends HttpServlet {
     Gson gson = new Gson();
     String[] commentKeys = gson.fromJson(request.getReader(), String[].class);
 
-    Query query =
-        new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
+    Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
 

--- a/leoism/step/portfolio/src/main/java/com/google/sps/servlets/AdminServlet.java
+++ b/leoism/step/portfolio/src/main/java/com/google/sps/servlets/AdminServlet.java
@@ -1,0 +1,99 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.gson.Gson;
+import com.google.sps.data.CommentInformation;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+import java.util.ArrayList;
+import java.util.Map;
+
+/**
+ * Servlet that returns some example content. TODO: modify this file to handle
+ * comments data
+ */
+@WebServlet("/admin")
+public class AdminServlet extends HttpServlet {
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+    UserService userService = UserServiceFactory.getUserService();
+
+    if (!userService.isUserLoggedIn()) {
+      String loginUrl = userService.createLoginURL("/admin");
+      response.sendRedirect(loginUrl);
+      return;
+    }
+
+    Query query =
+        new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    PreparedQuery results = datastore.prepare(query);
+
+    ArrayList<Map<String, Object>> comments =
+        new ArrayList<Map<String, Object>>();
+
+    for (Entity entity : results.asIterable()) {
+      comments.add(entity.getProperties());
+    }
+
+    request.setAttribute("commentData", comments);
+    request.getRequestDispatcher("/pages/AdminPage.jsp")
+        .forward(request, response);
+  }
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+    Gson gson = new Gson();
+    CommentInformation[] commentsInformation =
+        gson.fromJson(request.getReader(), CommentInformation[].class);
+
+    Query query =
+        new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    PreparedQuery results = datastore.prepare(query);
+
+    for (Entity entity : results.asIterable()) {
+      Map<String, Object> commentData = entity.getProperties();
+      // A conversion from Object to Long is not possible; therefore, cast to
+      // String before casting to Long.
+      String stringTimestamp = String.valueOf(commentData.get("timestamp"));
+      long dataStoreTimestamp = Long.parseLong(stringTimestamp);
+      for (CommentInformation comment : commentsInformation) {
+        // At the moment, the timestamp is closest unique element for each
+        // comment.
+        if (comment.getTimestamp() == dataStoreTimestamp) {
+          datastore.delete(entity.getKey());
+          break;
+        }
+      }
+    }
+  }
+}

--- a/leoism/step/portfolio/src/main/java/com/google/sps/servlets/AdminServlet.java
+++ b/leoism/step/portfolio/src/main/java/com/google/sps/servlets/AdminServlet.java
@@ -57,14 +57,7 @@ public class AdminServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
 
-    ArrayList<Map<String, Object>> comments =
-        new ArrayList<Map<String, Object>>();
-
-    for (Entity entity : results.asIterable()) {
-      comments.add(entity.getProperties());
-    }
-
-    request.setAttribute("commentData", comments);
+    request.setAttribute("commentData", results.asIterator());
     request.getRequestDispatcher("/pages/AdminPage.jsp")
         .forward(request, response);
   }
@@ -72,6 +65,14 @@ public class AdminServlet extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response)
       throws IOException {
+    UserService userService = UserServiceFactory.getUserService();
+
+    if (!userService.isUserLoggedIn()) {
+      String loginUrl = userService.createLoginURL("/admin");
+      response.sendRedirect(loginUrl);
+      return;
+    }
+
     Gson gson = new Gson();
     String[] commentKeys = gson.fromJson(request.getReader(), String[].class);
 

--- a/leoism/step/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/leoism/step/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -20,6 +20,8 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
 import com.google.cloud.language.v1.Document;
 import com.google.cloud.language.v1.LanguageServiceClient;
 import com.google.cloud.language.v1.Sentiment;
@@ -75,11 +77,21 @@ public class DataServlet extends HttpServlet {
       return;
     }
 
+    UserService userService = UserServiceFactory.getUserService();
+
+    if (!userService.isUserLoggedIn()) {
+      String loginUrl = userService.createLoginURL("/");
+      response.sendRedirect(loginUrl);
+      return;
+    }
+
+    String userEmail = userService.getCurrentUser().getEmail();
+
     double score = determineSentimentScore(comment);
 
     // Prevent users from submitting negative comments.
     if (score > 0.1) {
-      storeComment(comment, name, score);
+      storeComment(comment, name, score, userEmail);
       response.sendRedirect("/");
     } else {
       response.setContentType("text/html;");
@@ -87,12 +99,14 @@ public class DataServlet extends HttpServlet {
     }
   }
 
-  private void storeComment(String comment, String name, double sentimentScore) {
+  private void storeComment(String comment, String name, double sentimentScore,
+                            String email) {
     Entity commentEntity = new Entity("Comment");
     commentEntity.setProperty("comment", comment);
     commentEntity.setProperty("name", name);
     commentEntity.setProperty("timestamp", new Date().getTime());
     commentEntity.setProperty("sentimentScore", sentimentScore);
+    commentEntity.setProperty("email", email);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     datastore.put(commentEntity);

--- a/leoism/step/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/leoism/step/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -28,12 +28,12 @@ import com.google.cloud.language.v1.Sentiment;
 import com.google.gson.Gson;
 import com.google.sps.data.CommentInformation;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.ArrayList;
-import java.util.Date;
 
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/data")
@@ -54,7 +54,8 @@ public class DataServlet extends HttpServlet {
       long timestamp = (long) entity.getProperty("timestamp");
       double sentimentScore = (double) entity.getProperty("sentimentScore");
 
-      CommentInformation commentInformation = new CommentInformation(comment, name, timestamp, sentimentScore);
+      CommentInformation commentInformation =
+          new CommentInformation(comment, name, timestamp, sentimentScore);
 
       comments.add(commentInformation);
     }
@@ -98,8 +99,7 @@ public class DataServlet extends HttpServlet {
     }
   }
 
-  private void storeComment(String comment, String name, double sentimentScore,
-                            String email) {
+  private void storeComment(String comment, String name, double sentimentScore, String email) {
     Entity commentEntity = new Entity("Comment");
     commentEntity.setProperty("comment", comment);
     commentEntity.setProperty("name", name);
@@ -111,13 +111,10 @@ public class DataServlet extends HttpServlet {
   }
 
   private double determineSentimentScore(String comment) throws IOException {
-    Document doc = Document.newBuilder()
-                       .setContent(comment)
-                       .setType(Document.Type.PLAIN_TEXT)
-                       .build();
+    Document doc =
+        Document.newBuilder().setContent(comment).setType(Document.Type.PLAIN_TEXT).build();
     LanguageServiceClient languageService = LanguageServiceClient.create();
-    Sentiment sentiment =
-        languageService.analyzeSentiment(doc).getDocumentSentiment();
+    Sentiment sentiment = languageService.analyzeSentiment(doc).getDocumentSentiment();
     return sentiment.getScore();
   }
 }

--- a/leoism/step/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/leoism/step/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -17,6 +17,7 @@ package com.google.sps.servlets;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
@@ -53,9 +54,8 @@ public class DataServlet extends HttpServlet {
       String name = (String) entity.getProperty("name");
       long timestamp = (long) entity.getProperty("timestamp");
       double sentimentScore = (double) entity.getProperty("sentimentScore");
-
-      CommentInformation commentInformation =
-          new CommentInformation(comment, name, timestamp, sentimentScore);
+      String key = (String) entity.getProperty("key");
+      CommentInformation commentInformation = new CommentInformation(comment, name, timestamp, sentimentScore, key);
 
       comments.add(commentInformation);
     }
@@ -107,8 +107,13 @@ public class DataServlet extends HttpServlet {
     commentEntity.setProperty("timestamp", new Date().getTime());
     commentEntity.setProperty("sentimentScore", sentimentScore);
     commentEntity.setProperty("email", email);
-
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    datastore.put(commentEntity);
+    // To retrieve a proper key, the Datastore must first perform its 'put'
+    // batch actions to generate a key. Once the key is generated store it to
+    // allow identifying messages.
+    commentEntity.setProperty("key",
+                              KeyFactory.keyToString(commentEntity.getKey()));
     datastore.put(commentEntity);
   }
 

--- a/leoism/step/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/leoism/step/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -17,7 +17,6 @@ package com.google.sps.servlets;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
-import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
@@ -54,8 +53,8 @@ public class DataServlet extends HttpServlet {
       String name = (String) entity.getProperty("name");
       long timestamp = (long) entity.getProperty("timestamp");
       double sentimentScore = (double) entity.getProperty("sentimentScore");
-      String key = (String) entity.getProperty("key");
-      CommentInformation commentInformation = new CommentInformation(comment, name, timestamp, sentimentScore, key);
+
+      CommentInformation commentInformation = new CommentInformation(comment, name, timestamp, sentimentScore);
 
       comments.add(commentInformation);
     }
@@ -108,12 +107,6 @@ public class DataServlet extends HttpServlet {
     commentEntity.setProperty("sentimentScore", sentimentScore);
     commentEntity.setProperty("email", email);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    datastore.put(commentEntity);
-    // To retrieve a proper key, the Datastore must first perform its 'put'
-    // batch actions to generate a key. Once the key is generated store it to
-    // allow identifying messages.
-    commentEntity.setProperty("key",
-                              KeyFactory.keyToString(commentEntity.getKey()));
     datastore.put(commentEntity);
   }
 

--- a/leoism/step/portfolio/src/main/webapp/pages/AdminPage.jsp
+++ b/leoism/step/portfolio/src/main/webapp/pages/AdminPage.jsp
@@ -1,0 +1,44 @@
+<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>Admin Page</title>
+  <link href="../style.css" rel="stylesheet" type="text/css">
+</head>
+
+<body>
+  <script src="../script.js"></script>
+  <h1>Delete All Comments</h1>
+  <table class="table-style" id="comments-table" data-all-selected="false">
+    <tbody>
+      <tr>
+        <th class="table-header-style">
+          <input name="select-all" onclick="selectAll()" type="checkbox"/>
+        </th>
+        <th class="table-header-style">Name</th>
+        <th class="table-header-style">Email</th>
+        <th class="table-header-style">Sentiment</th>
+        <th class="table-header-style">Comment</th>
+        <th class="table-header-style">Timestamp</th>
+      </tr>
+      <c:forEach items="${commentData}" var="comment" varStatus="loop">
+        <tr>
+          <td class="table-text">
+            <input type="checkbox"/>
+          </td>
+          <td class="table-text">${comment.name}</td>
+          <td class="table-text">${comment.email}</td>
+          <td class="table-text">${comment.sentimentScore}</td>
+          <td class="table-text">${comment.comment}</td>
+          <td class="table-text">${comment.timestamp}</td>
+        </tr>
+      </c:forEach>
+    </tbody>
+  </table>
+  <input name="delete" onclick="submitButton()" type="submit" value="Delete Selected Comments"/>
+</body>
+
+</html>

--- a/leoism/step/portfolio/src/main/webapp/pages/AdminPage.jsp
+++ b/leoism/step/portfolio/src/main/webapp/pages/AdminPage.jsp
@@ -1,4 +1,5 @@
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@ page import="com.google.appengine.api.datastore.KeyFactory" %>
 
 <!DOCTYPE html>
 <html>
@@ -30,12 +31,12 @@
           <td class="table-text">
             <input type="checkbox"/>
           </td>
-          <td class="table-text">${comment.name}</td>
-          <td class="table-text">${comment.email}</td>
-          <td class="table-text">${comment.sentimentScore}</td>
-          <td class="table-text">${comment.comment}</td>
-          <td class="table-text">${comment.timestamp}</td>
-          <td class="table-text">${comment.key}</td>
+          <td class="table-text">${comment.getProperty("name")}</td>
+          <td class="table-text">${comment.getProperty("email")}</td>
+          <td class="table-text">${comment.getProperty("sentimentScore")}</td>
+          <td class="table-text">${comment.getProperty("comment")}</td>
+          <td class="table-text">${comment.getProperty("timestamp")}</td>
+          <td class="table-text">${KeyFactory.keyToString(comment.getKey())}</td>
         </tr>
       </c:forEach>
     </tbody>

--- a/leoism/step/portfolio/src/main/webapp/pages/AdminPage.jsp
+++ b/leoism/step/portfolio/src/main/webapp/pages/AdminPage.jsp
@@ -23,6 +23,7 @@
         <th class="table-header-style">Sentiment</th>
         <th class="table-header-style">Comment</th>
         <th class="table-header-style">Timestamp</th>
+        <th class="table-header-style">Key</th>
       </tr>
       <c:forEach items="${commentData}" var="comment" varStatus="loop">
         <tr>
@@ -34,6 +35,7 @@
           <td class="table-text">${comment.sentimentScore}</td>
           <td class="table-text">${comment.comment}</td>
           <td class="table-text">${comment.timestamp}</td>
+          <td class="table-text">${comment.key}</td>
         </tr>
       </c:forEach>
     </tbody>

--- a/leoism/step/portfolio/src/main/webapp/script.js
+++ b/leoism/step/portfolio/src/main/webapp/script.js
@@ -114,39 +114,34 @@ function selectAll() {
 
 function submitButton() {
   const url = '/admin';
-  const params = createParameters();
+  const commentKeys = createParameters();
   const xhr = new XMLHttpRequest();
   xhr.open('POST', url, true);
-  console.log(params);
+
+  if (commentKeys.length === 0) {
+    alert('There are no comments to delete!');
+    return;
+  }
+
   xhr.setRequestHeader('Content-type', 'application/json');
 
-  xhr.send(JSON.stringify(params));
+  xhr.send(JSON.stringify(commentKeys));
   alert('Refresh the Page to see the changes!');
 }
 
 function createParameters() {
-  const paramNamesObj = {
-    '1': 'name',
-    '2': 'email',
-    '3': 'sentimentScore',
-    '4': 'comment',
-    '5': 'timestamp'
-  };
-
-  let commentData = [];
+  let commentKeys = [];
 
   const table = document.getElementById('comments-table')
+  const commentKeyIdx = 6;
+
   for (let i = 1, row; row = table.rows[i]; i++) {
     const inputBox = row.cells[0].firstElementChild;
-    if (inputBox && inputBox.checked) {
-      commentData[`comment${i}`] = {};
-      let thisCommentData = commentData[`comment${i}`];
-      commentData.push(thisCommentData);
-      for (let j = 1, column; column = row.cells[j]; j++) {
-        thisCommentData[paramNamesObj[j]] = column.innerText;
-      }
+    const commentKeyBox = row.cells[commentKeyIdx];
+    if (inputBox && inputBox.checked && commentKeyBox) {
+      commentKeys.push(commentKeyBox.innerText);
     }
   }
 
-  return commentData;
+  return commentKeys;
 }

--- a/leoism/step/portfolio/src/main/webapp/script.js
+++ b/leoism/step/portfolio/src/main/webapp/script.js
@@ -98,3 +98,55 @@ function loadComments() {
     }
   });
 }
+
+function selectAll() {
+  const commentsTable = document.getElementById('comments-table');
+  const areAllSelected =
+      commentsTable.getAttribute('data-all-selected') == 'true';
+  const allInputBoxes = commentsTable.querySelectorAll('tbody>tr>td>input');
+
+  allInputBoxes.forEach((input) => {
+    input.checked = !areAllSelected;
+  });
+
+  commentsTable.setAttribute('data-all-selected', !areAllSelected);
+}
+
+function submitButton() {
+  const url = '/admin';
+  const params = createParameters();
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST', url, true);
+  console.log(params);
+  xhr.setRequestHeader('Content-type', 'application/json');
+
+  xhr.send(JSON.stringify(params));
+  alert('Refresh the Page to see the changes!');
+}
+
+function createParameters() {
+  const paramNamesObj = {
+    '1': 'name',
+    '2': 'email',
+    '3': 'sentimentScore',
+    '4': 'comment',
+    '5': 'timestamp'
+  };
+
+  let commentData = [];
+
+  const table = document.getElementById('comments-table')
+  for (let i = 1, row; row = table.rows[i]; i++) {
+    const inputBox = row.cells[0].firstElementChild;
+    if (inputBox && inputBox.checked) {
+      commentData[`comment${i}`] = {};
+      let thisCommentData = commentData[`comment${i}`];
+      commentData.push(thisCommentData);
+      for (let j = 1, column; column = row.cells[j]; j++) {
+        thisCommentData[paramNamesObj[j]] = column.innerText;
+      }
+    }
+  }
+
+  return commentData;
+}

--- a/leoism/step/portfolio/src/main/webapp/style.css
+++ b/leoism/step/portfolio/src/main/webapp/style.css
@@ -110,6 +110,32 @@
   flex: 1;
 }
 
+.table-style {
+  background-color: #63a4ff;
+  border-collapse: collapse;
+  font-family: arial, sans-serif;
+  width: 100%;
+}
+
+.table-text {
+  border-left: 1px solid #dddddd;
+  color: #fff;
+  padding: 8px;
+  text-align: left;
+}
+
+.table-header-style {
+  background-color: #004ba0;
+  border-bottom: 1px solid #dddddd;
+  color: #fff;
+  padding: 8px;
+  text-align: left;
+}
+
+tr:nth-child(even) {
+  background-color: #1976d2;
+}
+
 .title {
   background-color: #1976d2;
   color: #fff;


### PR DESCRIPTION
The Admin page displays all comments that Datastore is holding and it allows to selectively delete comments that the user wishes to delete. All comments selected by the user will be deleted on the Datastore.

This PR was created because after pulling changes from master into the PR https://github.com/googleinterns/step155-2020/pull/48 branch, previous commits already merged into master were added. This is meant to get rid of those commits that were added to the PR 