### PR TITLE
Remove .eslintrc.yml from workflows folder

### DIFF
--- a/.github/workflows/.eslintrc.yml
+++ b/.github/workflows/.eslintrc.yml
@@ -1,9 +1,0 @@
-env:
-  browser: true
-  commonjs: true
-  es2020: true
-extends:
-  - google
-parserOptions:
-  ecmaVersion: 11
-rules: {}


### PR DESCRIPTION
The .eslintrc.yml file is unnecessary since it was moved to the root directory of the repo. The file also confuses GitHub and makes it think that .eslintrc.yml is a workflow. GitHub [runs all YAML](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#about-yaml-syntax-for-workflows) files inside the workflow directory. This causes GitHub to run the .yml file; however, since it is not a workflow but rather a config file for the eslint linter, it [fails](https://github.com/googleinterns/step155-2020/actions/runs/177726686) as a test because it does not follow GitHub workflow syntax. Although the test does not show up when a PR is created, an email notification is sent stating the 'test' failed to run.