### PR TITLE
Fix issues on deployed version of webapp

### DIFF
--- a/capstone_project/pom.xml
+++ b/capstone_project/pom.xml
@@ -85,7 +85,7 @@
         <artifactId>appengine-maven-plugin</artifactId>
         <version>2.2.0</version>
         <configuration>
-          <deploy.projectId>gdconn-step</deploy.projectId>
+          <deploy.projectId>google.com:gdconn-step-2020</deploy.projectId>
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>

--- a/capstone_project/src/main/java/com/google/sps/data/PostService.java
+++ b/capstone_project/src/main/java/com/google/sps/data/PostService.java
@@ -79,7 +79,10 @@ public class PostService {
     initializeSorters();
   }
 
-  /** Returns the uploaded images' url if an image was uploaded. Otherwise, returns null. */
+  /**
+   * Returns the uploaded files' blob key string representation if a file was uploaded. Otherwise,
+   * returns null.
+   */
   public String uploadFile(HttpServletRequest request) {
     Map<String, List<BlobKey>> blobs = blobstore.getUploads(request);
     List<BlobKey> blobKeys = blobs.get("file");
@@ -91,7 +94,7 @@ public class PostService {
   }
 
   /**
-   * Stores the post text and image url into datastore. 'request' much have the parameter 'text'.
+   * Stores the post text and file blobkey into datastore. 'request' must have the parameter 'text'.
    */
   public void storePost(HttpServletRequest request) {
     Entity postEntity = new Entity("Post");
@@ -151,7 +154,7 @@ public class PostService {
     return entities;
   }
 
-  /** Initialized postSorters with method references to the sorting methods. */
+  /** Initializes postSorters with method references to the sorting methods. */
   private void initializeSorters() {
     postSorters.put("new", this::sortByNew);
     postSorters.put("top", this::sortByTop);

--- a/capstone_project/src/main/java/com/google/sps/data/PostService.java
+++ b/capstone_project/src/main/java/com/google/sps/data/PostService.java
@@ -108,7 +108,12 @@ public class PostService {
       fileType = "none";
     }
 
-    postEntity.setProperty("fileBlobKey", fileBlobKey.toString());
+    // Only set the fileBlobKey if there is one. There is no need to store a blobKey if there isn't
+    // one.
+    if (fileBlobKey.isPresent()) {
+      postEntity.setProperty("fileBlobKey", fileBlobKey.get());
+    }
+
     postEntity.setProperty("fileType", fileType);
     postEntity.setProperty("text", message);
     postEntity.setProperty("upvotes", 0);

--- a/capstone_project/src/main/java/com/google/sps/data/PostService.java
+++ b/capstone_project/src/main/java/com/google/sps/data/PostService.java
@@ -81,8 +81,8 @@ public class PostService {
   }
 
   /**
-   * Returns the uploaded files' blob key string representation if a file was uploaded. Otherwise,
-   * returns null.
+   * Returns the uploaded files' blob key string representation inside an Optional, if a file was
+   * uploaded. Otherwise, returns an empty Optional object.
    */
   public Optional<String> uploadFile(HttpServletRequest request) {
     Map<String, List<BlobKey>> blobs = blobstore.getUploads(request);

--- a/capstone_project/src/main/java/com/google/sps/data/PostService.java
+++ b/capstone_project/src/main/java/com/google/sps/data/PostService.java
@@ -30,6 +30,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -83,14 +84,15 @@ public class PostService {
    * Returns the uploaded files' blob key string representation if a file was uploaded. Otherwise,
    * returns null.
    */
-  public String uploadFile(HttpServletRequest request) {
+  public Optional<String> uploadFile(HttpServletRequest request) {
     Map<String, List<BlobKey>> blobs = blobstore.getUploads(request);
     List<BlobKey> blobKeys = blobs.get("file");
+
     if (blobKeys == null || blobKeys.isEmpty()) {
-      return null;
+      return Optional.empty();
     }
 
-    return blobKeys.get(0).getKeyString();
+    return Optional.ofNullable(blobKeys.get(0).getKeyString());
   }
 
   /**
@@ -100,13 +102,13 @@ public class PostService {
     Entity postEntity = new Entity("Post");
     String message = request.getParameter("text");
     String fileType = request.getParameter("file-type");
-    String fileBlobKey = uploadFile(request);
+    Optional<String> fileBlobKey = uploadFile(request);
 
     if (fileType == null || fileType.isEmpty()) {
       fileType = "none";
     }
 
-    postEntity.setProperty("fileBlobKey", fileBlobKey);
+    postEntity.setProperty("fileBlobKey", fileBlobKey.toString());
     postEntity.setProperty("fileType", fileType);
     postEntity.setProperty("text", message);
     postEntity.setProperty("upvotes", 0);

--- a/capstone_project/src/main/java/com/google/sps/servlets/FetchUrlServlet.java
+++ b/capstone_project/src/main/java/com/google/sps/servlets/FetchUrlServlet.java
@@ -1,0 +1,42 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Creates a blobstore url with a parameter for the file type. */
+@WebServlet("/fetch-blobstore-url")
+public class FetchUrlServlet extends HttpServlet {
+  private final BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String fileType = request.getParameter("file-type");
+
+    if (fileType == null || fileType.isEmpty()) {
+      return;
+    }
+
+    String uploadUrl = blobstoreService.createUploadUrl("/post-process?file-type=" + fileType);
+    response.setContentType("text/html");
+    response.getWriter().println(uploadUrl);
+  }
+}

--- a/capstone_project/src/main/java/com/google/sps/servlets/ServeServlet.java
+++ b/capstone_project/src/main/java/com/google/sps/servlets/ServeServlet.java
@@ -1,0 +1,42 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.blobstore.BlobKey;
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Manually serves an image, using the blobkey to create a url and send that url as a response. */
+@WebServlet("/serve-file")
+public class ServeServlet extends HttpServlet {
+  private final BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String blobKeyString = request.getParameter("blob-key");
+
+    if (blobKeyString == null || blobKeyString.isEmpty()) {
+      return;
+    }
+
+    BlobKey blobKey = new BlobKey(blobKeyString);
+    blobstoreService.serve(blobKey, response);
+  }
+}

--- a/capstone_project/src/main/webapp/pages/comments.jsp
+++ b/capstone_project/src/main/webapp/pages/comments.jsp
@@ -12,8 +12,7 @@ limitations under the License.
 --%>
 <%@ page import="com.google.appengine.api.blobstore.BlobstoreService" %>
 <%@ page import="com.google.appengine.api.blobstore.BlobstoreServiceFactory" %>
-<%! BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
-   String uploadUrl = blobstoreService.createUploadUrl("/post-process"); %>
+<%! BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService(); %>
 
 <!DOCTYPE html>
 <script src="../scripts/comments.js"></script>
@@ -26,14 +25,18 @@ limitations under the License.
   </div>
   <div id="user-posts" data-sort="default"></div>
   <hr>
-  <form method="POST" enctype="multipart/form-data" action="<%= uploadUrl %>">
+  <form action="<%= blobstoreService.createUploadUrl("/post-process?file-type=none") %>"
+        enctype="multipart/form-data"
+        id="post-input"
+        method="POST"
+        onsubmit="disableInput(event)">
     <textarea required id="post-entry" name="text"></textarea>
     <br>
     <img alt="" id="image-preview" src="//:0">
     <br>
-    <input accept="image/*"
+    <input accept="image/*,video/*"
            id="image-upload"
-           name="image"
+           name="file"
            onchange="previewImage(event)"
            type="file">
     <br>

--- a/capstone_project/src/main/webapp/styles/posts.css
+++ b/capstone_project/src/main/webapp/styles/posts.css
@@ -5,7 +5,7 @@
   width: 50%;
 }
 
-.post-image {
+.post-file {
   width: 100%;
 }
 

--- a/capstone_project/src/test/java/com/google/sps/PostTest.java
+++ b/capstone_project/src/test/java/com/google/sps/PostTest.java
@@ -81,7 +81,7 @@ public final class PostTest extends Mockito {
 
     // Mock blobstore to return the prebuilt blobs
     when(blobstoreService.getUploads(request)).thenReturn(blobs);
-    Optional<String> expected = Optional.ofNullable(null);
+    Optional<String> expected = Optional.empty();
     Optional<String> actual = postService.uploadFile(request);
     assertEquals(expected, actual);
   }

--- a/capstone_project/src/test/java/com/google/sps/PostTest.java
+++ b/capstone_project/src/test/java/com/google/sps/PostTest.java
@@ -22,8 +22,6 @@ import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.EntityNotFoundException;
 import com.google.appengine.api.datastore.Key;
-import com.google.appengine.api.images.ImagesService;
-import com.google.appengine.api.images.ServingUrlOptions;
 import com.google.appengine.tools.development.testing.LocalBlobstoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
@@ -45,7 +43,6 @@ import org.mockito.Mockito;
 public final class PostTest extends Mockito {
   private DatastoreService datastore;
   private BlobstoreService blobstoreService;
-  private ImagesService imagesService;
   private Clock clock;
   private HttpServletRequest request;
   private LocalServiceTestHelper serviceHelper =
@@ -58,7 +55,6 @@ public final class PostTest extends Mockito {
     serviceHelper.setUp();
     datastore = Mockito.mock(DatastoreService.class);
     blobstoreService = Mockito.mock(BlobstoreService.class);
-    imagesService = Mockito.mock(ImagesService.class);
     request = Mockito.mock(HttpServletRequest.class);
     clock = Mockito.mock(Clock.class);
     postService =
@@ -66,7 +62,6 @@ public final class PostTest extends Mockito {
             PostService.Builder.builder()
                 .datastore(datastore)
                 .blobstore(blobstoreService)
-                .imagesService(imagesService)
                 .clock(clock)
                 .build());
   }
@@ -86,7 +81,7 @@ public final class PostTest extends Mockito {
     // Mock blobstore to return the prebuilt blobs
     when(blobstoreService.getUploads(request)).thenReturn(blobs);
     String expected = null;
-    String actual = postService.uploadImage(request);
+    String actual = postService.uploadFile(request);
     assertEquals(expected, actual);
   }
 
@@ -94,20 +89,19 @@ public final class PostTest extends Mockito {
   public void returnUrlBlobstore() {
     List<BlobKey> blobKeys = Arrays.asList(new BlobKey("BlobKey"));
     Map<String, List<BlobKey>> blobs = new HashMap<>();
-    blobs.put("image", blobKeys);
+    blobs.put("file", blobKeys);
 
     // Mock blobstore to return the prebuilt blobs.
     when(blobstoreService.getUploads(request)).thenReturn(blobs);
     // Since the blobkey does not exist in the blobstore, it is mocked to return a link.
-    when(imagesService.getServingUrl(any(ServingUrlOptions.class))).thenReturn("/link_to_image");
-    String expected = "/link_to_image";
-    String actual = postService.uploadImage(request);
+    String expected = "BlobKey";
+    String actual = postService.uploadFile(request);
     assertEquals(expected, actual);
   }
 
   @Test
   public void urlStoredInDatastore() {
-    doReturn("link_to_image").when(postService).uploadImage(request);
+    doReturn("BlobKey").when(postService).uploadFile(request);
     postService.storePost(request);
 
     verify(datastore).put(any(Entity.class));

--- a/capstone_project/src/test/java/com/google/sps/PostTest.java
+++ b/capstone_project/src/test/java/com/google/sps/PostTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.After;
 import org.junit.Before;
@@ -80,8 +81,8 @@ public final class PostTest extends Mockito {
 
     // Mock blobstore to return the prebuilt blobs
     when(blobstoreService.getUploads(request)).thenReturn(blobs);
-    String expected = null;
-    String actual = postService.uploadFile(request);
+    Optional<String> expected = Optional.ofNullable(null);
+    Optional<String> actual = postService.uploadFile(request);
     assertEquals(expected, actual);
   }
 
@@ -94,14 +95,14 @@ public final class PostTest extends Mockito {
     // Mock blobstore to return the prebuilt blobs.
     when(blobstoreService.getUploads(request)).thenReturn(blobs);
     // Since the blobkey does not exist in the blobstore, it is mocked to return a link.
-    String expected = "BlobKey";
-    String actual = postService.uploadFile(request);
+    Optional<String> expected = Optional.of("BlobKey");
+    Optional<String> actual = postService.uploadFile(request);
     assertEquals(expected, actual);
   }
 
   @Test
   public void urlStoredInDatastore() {
-    doReturn("BlobKey").when(postService).uploadFile(request);
+    doReturn(Optional.of("BlobKey")).when(postService).uploadFile(request);
     postService.storePost(request);
 
     verify(datastore).put(any(Entity.class));


### PR DESCRIPTION
+ Blobstore works on a local dev server; however, when deployed, serving an image url does not work. We have to manuailly serve the image each time instead of having blobstore doing it automatically.
+ Add file check to allow posting videos and images, with their proper tags
+ Create a function to fetch an upload url from blobstore whenever a new file is picked. This is to prevent invalid upload sessions and have the server use the proper html tag for the file