### PR TITLE
Add 24 hour feature to posts

### DIFF
--- a/capstone_project/pom.xml
+++ b/capstone_project/pom.xml
@@ -35,8 +35,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>3.4.4</version>
+      <artifactId>mockito-inline</artifactId>
+      <version>3.4.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -73,6 +73,16 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-datastore</artifactId>
+      <version>1.104.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.functions</groupId>
+      <artifactId>functions-framework-api</artifactId>
+      <version>1.0.1</version>
     </dependency>
   </dependencies>
 

--- a/capstone_project/src/main/java/com/google/sps/data/DeletePostService.java
+++ b/capstone_project/src/main/java/com/google/sps/data/DeletePostService.java
@@ -17,7 +17,6 @@
 package com.google.sps.data;
 
 import com.google.cloud.datastore.Datastore;
-import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
@@ -38,17 +37,13 @@ public class DeletePostService {
   private Datastore datastore;
   private Clock clock;
 
-  public DeletePostService() {
-    this.datastore = DatastoreOptions.getDefaultInstance().getService();
+  public DeletePostService(Datastore datastore) {
+    this.datastore = datastore;
     this.clock = Clock.systemUTC();
   }
 
   public void setClock(Clock clock) {
     this.clock = clock;
-  }
-
-  public void setDatastore(Datastore datastore) {
-    this.datastore = datastore;
   }
 
   // Retrieves a query of all posts entities in ascending order based on timestamp. Returns a list

--- a/capstone_project/src/main/java/com/google/sps/data/DeletePostService.java
+++ b/capstone_project/src/main/java/com/google/sps/data/DeletePostService.java
@@ -37,12 +37,8 @@ public class DeletePostService {
   private Datastore datastore;
   private Clock clock;
 
-  public DeletePostService(Datastore datastore) {
+  public DeletePostService(Datastore datastore, Clock clock) {
     this.datastore = datastore;
-    this.clock = Clock.systemUTC();
-  }
-
-  public void setClock(Clock clock) {
     this.clock = clock;
   }
 

--- a/capstone_project/src/main/java/com/google/sps/data/DeletePostService.java
+++ b/capstone_project/src/main/java/com/google/sps/data/DeletePostService.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.sps.data;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
+import com.google.cloud.datastore.StructuredQuery.OrderBy;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Service for deleting posts that were created longer than 24 hours ago. Note: This uses google
+ * cloud datastore since a cloud function does not have access to app engine datstore properties.
+ * Cloud datastore uses the same database as app engine. The only differences are in API usages and
+ * methods.
+ */
+public class DeletePostService {
+  // Represents one day in milliseconds
+  private final long ONE_DAY = 86400000;
+  private Datastore datastore;
+  private Clock clock;
+
+  public DeletePostService() {
+    this.datastore = DatastoreOptions.getDefaultInstance().getService();
+    this.clock = Clock.systemUTC();
+  }
+
+  public void setClock(Clock clock) {
+    this.clock = clock;
+  }
+
+  public void setDatastore(Datastore datastore) {
+    this.datastore = datastore;
+  }
+
+  // Retrieves a query of all posts entities in ascending order based on timestamp. Returns a list
+  // of entities of all posts inside of datastore in sorted ascending order.
+  public List<Entity> retrieveAllPosts() {
+    Query<Entity> query =
+        Query.newEntityQueryBuilder().setKind("Post").setOrderBy(OrderBy.asc("timestamp")).build();
+
+    QueryResults<Entity> queriedPosts = datastore.run(query);
+    List<Entity> posts = new ArrayList<>();
+    queriedPosts.forEachRemaining(posts::add);
+    return posts;
+  }
+
+  // Calculates the elasped time since the post entity was uploaded. Returns true if more than 24
+  // hours have elapased since its creation time. Otherwise, returns false.
+  private boolean isOlderThan24Hours(Entity post) {
+    long creationTime = post.getLong("timestamp");
+    long currentTime = clock.millis();
+    long elapsedTime = currentTime - creationTime;
+
+    return elapsedTime >= ONE_DAY;
+  }
+
+  // Deletes all posts with an elapsed time equal to or older than 24 hours from its creation time.
+  public void deleteOldPosts() {
+    List<Entity> posts = retrieveAllPosts();
+    if (posts.isEmpty()) {
+      return;
+    }
+
+    for (Entity post : posts) {
+      if (isOlderThan24Hours(post)) {
+        datastore.delete(post.getKey());
+      } else {
+        // These are sorted in ascended order largest to smallest timestamp (larger timestamp means
+        // newer date), which means that as soon as one is not older than 24 hours, the remaining
+        // ones are also less than 24 hours.
+        break;
+      }
+    }
+  }
+}

--- a/capstone_project/src/main/java/com/google/sps/data/DeletePostService.java
+++ b/capstone_project/src/main/java/com/google/sps/data/DeletePostService.java
@@ -39,7 +39,11 @@ public class DeletePostService {
   private Clock clock;
 
   public DeletePostService() {
-    this.datastore = DatastoreOptions.getDefaultInstance().getService();
+    this.datastore =
+        DatastoreOptions.newBuilder()
+            .setProjectId("google.com:gdconn-step-2020")
+            .build()
+            .getService();
     this.clock = Clock.systemUTC();
   }
 

--- a/capstone_project/src/main/java/com/google/sps/data/DeletePostService.java
+++ b/capstone_project/src/main/java/com/google/sps/data/DeletePostService.java
@@ -39,11 +39,7 @@ public class DeletePostService {
   private Clock clock;
 
   public DeletePostService() {
-    this.datastore =
-        DatastoreOptions.newBuilder()
-            .setProjectId("google.com:gdconn-step-2020")
-            .build()
-            .getService();
+    this.datastore = DatastoreOptions.getDefaultInstance().getService();
     this.clock = Clock.systemUTC();
   }
 

--- a/capstone_project/src/main/java/com/google/sps/data/DeletePostService.java
+++ b/capstone_project/src/main/java/com/google/sps/data/DeletePostService.java
@@ -44,7 +44,7 @@ public class DeletePostService {
 
   // Retrieves a query of all posts entities in ascending order based on timestamp. Returns a list
   // of entities of all posts inside of datastore in sorted ascending order.
-  public List<Entity> retrieveAllPosts() {
+  public List<Entity> retrieveAllPostsAscending() {
     Query<Entity> query =
         Query.newEntityQueryBuilder().setKind("Post").setOrderBy(OrderBy.asc("timestamp")).build();
 
@@ -66,7 +66,7 @@ public class DeletePostService {
 
   // Deletes all posts with an elapsed time equal to or older than 24 hours from its creation time.
   public void deleteOldPosts() {
-    List<Entity> posts = retrieveAllPosts();
+    List<Entity> posts = retrieveAllPostsAscending();
     if (posts.isEmpty()) {
       return;
     }

--- a/capstone_project/src/main/java/com/google/sps/data/DeletePostService.java
+++ b/capstone_project/src/main/java/com/google/sps/data/DeletePostService.java
@@ -44,7 +44,7 @@ public class DeletePostService {
 
   // Retrieves a query of all posts entities in ascending order based on timestamp. Returns a list
   // of entities of all posts inside of datastore in sorted ascending order.
-  public List<Entity> retrieveAllPostsAscending() {
+  private List<Entity> retrieveAllPostsAscending() {
     Query<Entity> query =
         Query.newEntityQueryBuilder().setKind("Post").setOrderBy(OrderBy.asc("timestamp")).build();
 

--- a/capstone_project/src/main/java/com/google/sps/data/DeletePosts.java
+++ b/capstone_project/src/main/java/com/google/sps/data/DeletePosts.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.sps.data;
+
+import com.google.cloud.functions.BackgroundFunction;
+import com.google.cloud.functions.Context;
+
+/**
+ * Cloud function that runs when triggered by a PubSubMessage. Deletes all posts that are older than
+ * 24 hours. Note: This uses google cloud datastore since a cloud function does not have access to
+ * app engine datstore properties. Cloud datastore uses the same database as app engine. The only
+ * differences are in API usages and methods.
+ */
+public class DeletePosts implements BackgroundFunction<PubSubMessage> {
+  @Override
+  public void accept(PubSubMessage message, Context context) {
+    DeletePostService deleteService = new DeletePostService();
+    deleteService.deleteOldPosts();
+  }
+}

--- a/capstone_project/src/main/java/com/google/sps/data/DeletePosts.java
+++ b/capstone_project/src/main/java/com/google/sps/data/DeletePosts.java
@@ -22,9 +22,9 @@ import com.google.cloud.functions.BackgroundFunction;
 import com.google.cloud.functions.Context;
 
 /**
- * Cloud function that runs when triggered by a PubSubMessa e. Deletes all posts that are older th
- * 24 hours. Note: This uses google clou datastore since a cloud function does not have access t app
- * engine datstor properties. Cloud datastore uses the same database as app engine. The only
+ * Cloud function that runs when triggered by a PubSubMessage. Deletes all posts that are older the
+ * 24 hours. Note: This uses google cloud datastore since a cloud function does not have access to
+ * app engine datastore properties. Cloud datastore uses the same database as app engine. The only
  * differences are in API usages and methods.
  */
 public class DeletePosts implements BackgroundFunction<PubSubMessage> {

--- a/capstone_project/src/main/java/com/google/sps/data/DeletePosts.java
+++ b/capstone_project/src/main/java/com/google/sps/data/DeletePosts.java
@@ -16,19 +16,23 @@
 
 package com.google.sps.data;
 
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.functions.BackgroundFunction;
 import com.google.cloud.functions.Context;
 
 /**
- * Cloud function that runs when triggered by a PubSubMessage. Deletes all posts that are older than
- * 24 hours. Note: This uses google cloud datastore since a cloud function does not have access to
- * app engine datstore properties. Cloud datastore uses the same database as app engine. The only
+ * Cloud function that runs when triggered by a PubSubMessa e. Deletes all posts that are older th
+ * 24 hours. Note: This uses google clou datastore since a cloud function does not have access t app
+ * engine datstor properties. Cloud datastore uses the same database as app engine. The only
  * differences are in API usages and methods.
  */
 public class DeletePosts implements BackgroundFunction<PubSubMessage> {
+  private Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
+
   @Override
   public void accept(PubSubMessage message, Context context) {
-    DeletePostService deleteService = new DeletePostService();
+    DeletePostService deleteService = new DeletePostService(datastore);
     deleteService.deleteOldPosts();
   }
 }

--- a/capstone_project/src/main/java/com/google/sps/data/DeletePosts.java
+++ b/capstone_project/src/main/java/com/google/sps/data/DeletePosts.java
@@ -20,6 +20,7 @@ import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.functions.BackgroundFunction;
 import com.google.cloud.functions.Context;
+import java.time.Clock;
 
 /**
  * Cloud function that runs when triggered by a PubSubMessage. Deletes all posts that are older the
@@ -32,7 +33,7 @@ public class DeletePosts implements BackgroundFunction<PubSubMessage> {
 
   @Override
   public void accept(PubSubMessage message, Context context) {
-    DeletePostService deleteService = new DeletePostService(datastore);
+    DeletePostService deleteService = new DeletePostService(datastore, Clock.systemUTC());
     deleteService.deleteOldPosts();
   }
 }

--- a/capstone_project/src/main/java/com/google/sps/data/PubSubMessage.java
+++ b/capstone_project/src/main/java/com/google/sps/data/PubSubMessage.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.sps.data;
+
+import java.util.Map;
+
+public class PubSubMessage {
+  // Cloud Functions uses GSON to populate this object.
+  // Field types/names are specified by Cloud Functions
+  // Changing them may break your code!
+  private String data;
+  private Map<String, String> attributes;
+  private String messageId;
+  private String publishTime;
+
+  public String getData() {
+    return data;
+  }
+
+  public void setData(String data) {
+    this.data = data;
+  }
+
+  public Map<String, String> getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(Map<String, String> attributes) {
+    this.attributes = attributes;
+  }
+
+  public String getMessageId() {
+    return messageId;
+  }
+
+  public void setMessageId(String messageId) {
+    this.messageId = messageId;
+  }
+
+  public String getPublishTime() {
+    return publishTime;
+  }
+
+  public void setPublishTime(String publishTime) {
+    this.publishTime = publishTime;
+  }
+}

--- a/capstone_project/src/main/java/com/google/sps/data/PubSubMessage.java
+++ b/capstone_project/src/main/java/com/google/sps/data/PubSubMessage.java
@@ -31,28 +31,28 @@ public class PubSubMessage {
     return data;
   }
 
-  public void setData(String data) {
-    this.data = data;
-  }
-
   public Map<String, String> getAttributes() {
     return attributes;
   }
 
-  public void setAttributes(Map<String, String> attributes) {
-    this.attributes = attributes;
+  public String getPublishTime() {
+    return publishTime;
   }
 
   public String getMessageId() {
     return messageId;
   }
 
-  public void setMessageId(String messageId) {
-    this.messageId = messageId;
+  public void setData(String data) {
+    this.data = data;
   }
 
-  public String getPublishTime() {
-    return publishTime;
+  public void setAttributes(Map<String, String> attributes) {
+    this.attributes = attributes;
+  }
+
+  public void setMessageId(String messageId) {
+    this.messageId = messageId;
   }
 
   public void setPublishTime(String publishTime) {

--- a/capstone_project/src/main/java/com/google/sps/servlets/PostServlet.java
+++ b/capstone_project/src/main/java/com/google/sps/servlets/PostServlet.java
@@ -39,7 +39,6 @@ public class PostServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     List<Entity> posts = datastore.prepare(query).asList(FetchOptions.Builder.withDefaults());
-
     Gson gson = new Gson();
     response.getWriter().println(gson.toJson(posts));
   }

--- a/capstone_project/src/test/java/com/google/sps/DeletePostTest.java
+++ b/capstone_project/src/test/java/com/google/sps/DeletePostTest.java
@@ -15,9 +15,7 @@
 package com.google.sps;
 
 import com.google.cloud.datastore.Datastore;
-import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.datastore.Entity;
-import com.google.cloud.datastore.Key;
 import com.google.sps.data.DeletePostService;
 import java.time.Clock;
 import java.util.Arrays;
@@ -30,12 +28,7 @@ import org.mockito.Mockito;
 
 @RunWith(JUnit4.class)
 public final class DeletePostTest extends Mockito {
-  private Datastore datastore =
-      spy(
-          DatastoreOptions.newBuilder()
-              .setProjectId("google.com:gdconn-step-2020")
-              .build()
-              .getService());
+  private Datastore datastore = mock(Datastore.class);
   private DeletePostService deleteService;
   private Clock clock;
   private final long ONE_DAY = 86400000L;
@@ -50,29 +43,33 @@ public final class DeletePostTest extends Mockito {
 
   @Test
   public void postIsDeletedWhenOlderThan24Hours() {
-    Key key = datastore.newKeyFactory().setKind("Post").newKey("someKey");
-    Entity post1 = Entity.newBuilder(key).set("timestamp", 0L).build();
+    Entity post1 = mock(Entity.class);
 
+    when(post1.getLong("timestamp")).thenReturn(0L);
     when(clock.millis()).thenReturn(ONE_DAY + 1);
+
     List<Entity> posts = Arrays.asList(post1);
     doReturn(posts).when(deleteService).retrieveAllPosts();
+
     deleteService.deleteOldPosts();
-    verify(datastore, times(1)).delete(any(Key.class));
+    verify(datastore, times(1)).delete(any());
   }
 
   @Test
   public void postsNotOlderThan24HoursNotDeleted() {
-    Key key1 = datastore.newKeyFactory().setKind("Post").newKey("someKey1");
-    Key key2 = datastore.newKeyFactory().setKind("Post").newKey("someKey2");
-    Key key3 = datastore.newKeyFactory().setKind("Post").newKey("someKey3");
-    Entity post1 = Entity.newBuilder(key1).set("timestamp", 0L).build();
-    Entity post2 = Entity.newBuilder(key2).set("timestamp", 0L).build();
-    Entity post3 = Entity.newBuilder(key3).set("timestamp", ONE_DAY).build();
+    Entity post1 = mock(Entity.class);
+    Entity post2 = mock(Entity.class);
+    Entity post3 = mock(Entity.class);
 
+    when(post1.getLong("timestamp")).thenReturn(0L);
+    when(post2.getLong("timestamp")).thenReturn(0L);
+    when(post3.getLong("timestamp")).thenReturn(ONE_DAY);
     when(clock.millis()).thenReturn(ONE_DAY);
+
     List<Entity> posts = Arrays.asList(post1, post2, post3);
     doReturn(posts).when(deleteService).retrieveAllPosts();
+
     deleteService.deleteOldPosts();
-    verify(datastore, times(2)).delete(any(Key.class));
+    verify(datastore, times(2)).delete(any());
   }
 }

--- a/capstone_project/src/test/java/com/google/sps/DeletePostTest.java
+++ b/capstone_project/src/test/java/com/google/sps/DeletePostTest.java
@@ -16,15 +16,19 @@ package com.google.sps;
 
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
 import com.google.sps.data.DeletePostService;
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 
 @RunWith(JUnit4.class)
 public final class DeletePostTest extends Mockito {
@@ -47,10 +51,18 @@ public final class DeletePostTest extends Mockito {
     when(clock.millis()).thenReturn(ONE_DAY + 1);
 
     List<Entity> posts = Arrays.asList(post1);
-    doReturn(posts).when(deleteService).retrieveAllPostsAscending();
+    QueryResults<Entity> queriedPosts = mock(QueryResults.class);
+    when(datastore.run(any(Query.class))).thenReturn(queriedPosts);
 
+    doAnswer(invocation -> mockForEachRemaining(invocation, posts))
+        .when(queriedPosts)
+        .forEachRemaining(any(Consumer.class));
     deleteService.deleteOldPosts();
+
     verify(datastore, times(1)).delete(any());
+    // Since post.getKey is only called when datastore.delete is called, we can assure it will only
+    // get called on posts older than 24 hours.
+    verify(post1).getKey();
   }
 
   @Test
@@ -65,9 +77,29 @@ public final class DeletePostTest extends Mockito {
     when(clock.millis()).thenReturn(ONE_DAY);
 
     List<Entity> posts = Arrays.asList(post1, post2, post3);
-    doReturn(posts).when(deleteService).retrieveAllPostsAscending();
+    QueryResults<Entity> queriedPosts = mock(QueryResults.class);
+    when(datastore.run(any(Query.class))).thenReturn(queriedPosts);
 
+    doAnswer(invocation -> mockForEachRemaining(invocation, posts))
+        .when(queriedPosts)
+        .forEachRemaining(any(Consumer.class));
     deleteService.deleteOldPosts();
+
     verify(datastore, times(2)).delete(any());
+    // Since post.getKey is only called when datastore.delete is called, we can assure it will only
+    // get called on posts older than 24 hours.
+    verify(post1).getKey();
+    verify(post2).getKey();
+    verify(post3, never()).getKey();
+  }
+
+  // Mocks the forEachRemaining method of an Iterator. Adds the provided posts to the list
+  // that was passed in through the Consumer.
+  private Void mockForEachRemaining(InvocationOnMock invocation, List<Entity> posts) {
+    Consumer<Entity> action = (Consumer<Entity>) invocation.getArguments()[0];
+    for (Entity post : posts) {
+      action.accept(post);
+    }
+    return null;
   }
 }

--- a/capstone_project/src/test/java/com/google/sps/DeletePostTest.java
+++ b/capstone_project/src/test/java/com/google/sps/DeletePostTest.java
@@ -36,8 +36,7 @@ public final class DeletePostTest extends Mockito {
   @Before
   public void setUpServiceHelper() {
     clock = mock(Clock.class);
-    deleteService = spy(new DeletePostService(datastore));
-    deleteService.setClock(clock);
+    deleteService = spy(new DeletePostService(datastore, clock));
   }
 
   @Test

--- a/capstone_project/src/test/java/com/google/sps/DeletePostTest.java
+++ b/capstone_project/src/test/java/com/google/sps/DeletePostTest.java
@@ -30,7 +30,12 @@ import org.mockito.Mockito;
 
 @RunWith(JUnit4.class)
 public final class DeletePostTest extends Mockito {
-  private Datastore datastore = spy(DatastoreOptions.getDefaultInstance().getService());
+  private Datastore datastore =
+      spy(
+          DatastoreOptions.newBuilder()
+              .setProjectId("google.com:gdconn-step-2020")
+              .build()
+              .getService());
   private DeletePostService deleteService;
   private Clock clock;
   private final long ONE_DAY = 86400000L;

--- a/capstone_project/src/test/java/com/google/sps/DeletePostTest.java
+++ b/capstone_project/src/test/java/com/google/sps/DeletePostTest.java
@@ -36,9 +36,8 @@ public final class DeletePostTest extends Mockito {
   @Before
   public void setUpServiceHelper() {
     clock = mock(Clock.class);
-    deleteService = spy(new DeletePostService());
+    deleteService = spy(new DeletePostService(datastore));
     deleteService.setClock(clock);
-    deleteService.setDatastore(datastore);
   }
 
   @Test

--- a/capstone_project/src/test/java/com/google/sps/DeletePostTest.java
+++ b/capstone_project/src/test/java/com/google/sps/DeletePostTest.java
@@ -47,7 +47,7 @@ public final class DeletePostTest extends Mockito {
     when(clock.millis()).thenReturn(ONE_DAY + 1);
 
     List<Entity> posts = Arrays.asList(post1);
-    doReturn(posts).when(deleteService).retrieveAllPosts();
+    doReturn(posts).when(deleteService).retrieveAllPostsAscending();
 
     deleteService.deleteOldPosts();
     verify(datastore, times(1)).delete(any());
@@ -65,7 +65,7 @@ public final class DeletePostTest extends Mockito {
     when(clock.millis()).thenReturn(ONE_DAY);
 
     List<Entity> posts = Arrays.asList(post1, post2, post3);
-    doReturn(posts).when(deleteService).retrieveAllPosts();
+    doReturn(posts).when(deleteService).retrieveAllPostsAscending();
 
     deleteService.deleteOldPosts();
     verify(datastore, times(2)).delete(any());

--- a/capstone_project/src/test/java/com/google/sps/DeletePostTest.java
+++ b/capstone_project/src/test/java/com/google/sps/DeletePostTest.java
@@ -1,0 +1,73 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.Key;
+import com.google.sps.data.DeletePostService;
+import java.time.Clock;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public final class DeletePostTest extends Mockito {
+  private Datastore datastore = spy(DatastoreOptions.getDefaultInstance().getService());
+  private DeletePostService deleteService;
+  private Clock clock;
+  private final long ONE_DAY = 86400000L;
+
+  @Before
+  public void setUpServiceHelper() {
+    clock = mock(Clock.class);
+    deleteService = spy(new DeletePostService());
+    deleteService.setClock(clock);
+    deleteService.setDatastore(datastore);
+  }
+
+  @Test
+  public void postIsDeletedWhenOlderThan24Hours() {
+    Key key = datastore.newKeyFactory().setKind("Post").newKey("someKey");
+    Entity post1 = Entity.newBuilder(key).set("timestamp", 0L).build();
+
+    when(clock.millis()).thenReturn(ONE_DAY + 1);
+    List<Entity> posts = Arrays.asList(post1);
+    doReturn(posts).when(deleteService).retrieveAllPosts();
+    deleteService.deleteOldPosts();
+    verify(datastore, times(1)).delete(any(Key.class));
+  }
+
+  @Test
+  public void postsNotOlderThan24HoursNotDeleted() {
+    Key key1 = datastore.newKeyFactory().setKind("Post").newKey("someKey1");
+    Key key2 = datastore.newKeyFactory().setKind("Post").newKey("someKey2");
+    Key key3 = datastore.newKeyFactory().setKind("Post").newKey("someKey3");
+    Entity post1 = Entity.newBuilder(key1).set("timestamp", 0L).build();
+    Entity post2 = Entity.newBuilder(key2).set("timestamp", 0L).build();
+    Entity post3 = Entity.newBuilder(key3).set("timestamp", ONE_DAY).build();
+
+    when(clock.millis()).thenReturn(ONE_DAY);
+    List<Entity> posts = Arrays.asList(post1, post2, post3);
+    doReturn(posts).when(deleteService).retrieveAllPosts();
+    deleteService.deleteOldPosts();
+    verify(datastore, times(2)).delete(any(Key.class));
+  }
+}


### PR DESCRIPTION
+ Create a CloudFunction that runs a batch operation on all post entities.
+ Delete a post if the amount of time since creation has passed 24 hours.
+ Add Tests to check that only posts older than or equal to 24 hours are deleted