### PR TITLE
Use Text instead of String

### DIFF
--- a/capstone_project/src/main/java/com/google/sps/data/PostService.java
+++ b/capstone_project/src/main/java/com/google/sps/data/PostService.java
@@ -24,6 +24,7 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.EntityNotFoundException;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.Text;
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.Collections;
@@ -101,7 +102,7 @@ public class PostService {
    */
   public void storePost(HttpServletRequest request) {
     Entity postEntity = new Entity("Post");
-    String message = request.getParameter("text");
+    Text message = new Text(request.getParameter("text"));
     String fileType = request.getParameter("file-type");
     Optional<String> fileBlobKey = uploadFile(request);
 

--- a/capstone_project/src/main/webapp/scripts/comments.js
+++ b/capstone_project/src/main/webapp/scripts/comments.js
@@ -128,7 +128,7 @@ async function renderPosts(posts) {
 
     const HTML = `
       ${getProperFileTag(postProperties.fileType, postProperties.fileBlobKey)}
-      <p>${postProperties.text}</p>
+      <p>${postProperties.text.value.value}</p>
       <div class='interactions'>
         <button class='upvote-button'
                 onclick='upvotePost(this)'>


### PR DESCRIPTION
+ Allow Strings of any size to be stored within Datastore by using Datastores Text class.

If a user were to write a post with a String size greater than 1500 bytes, the Datastore would throw an IllegalArgumentException. Using Datastores Text class, we can avoid that.